### PR TITLE
Add to_array macros that can specify length & initial fill value

### DIFF
--- a/const-str/src/__ctfe/concat_bytes.rs
+++ b/const-str/src/__ctfe/concat_bytes.rs
@@ -6,7 +6,7 @@ impl ConcatBytesPart<u8> {
     }
 
     pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(&[self.0])
+        crate::bytes::clone(&[self.0], 0)
     }
 }
 
@@ -16,7 +16,7 @@ impl<const L: usize> ConcatBytesPart<&[u8; L]> {
     }
 
     pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(self.0)
+        crate::bytes::clone(self.0, 0)
     }
 }
 
@@ -26,7 +26,7 @@ impl ConcatBytesPart<&[u8]> {
     }
 
     pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(self.0)
+        crate::bytes::clone(self.0, 0)
     }
 }
 
@@ -36,7 +36,7 @@ impl<const L: usize> ConcatBytesPart<[u8; L]> {
     }
 
     pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(&self.0)
+        crate::bytes::clone(&self.0, 0)
     }
 }
 
@@ -46,7 +46,7 @@ impl ConcatBytesPart<&str> {
     }
 
     pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(self.0.as_bytes())
+        crate::bytes::clone(self.0.as_bytes(), 0)
     }
 }
 

--- a/const-str/src/__ctfe/encode.rs
+++ b/const-str/src/__ctfe/encode.rs
@@ -34,7 +34,7 @@ impl<'a> Encode<'a, Utf8Encoder> {
             assert!(i + 1 == N);
             buf
         } else {
-            crate::bytes::clone(bytes)
+            crate::bytes::clone(bytes, 0)
         }
     }
 }

--- a/const-str/src/__ctfe/str.rs
+++ b/const-str/src/__ctfe/str.rs
@@ -23,7 +23,7 @@ impl<const N: usize> StrBuf<N> {
     }
 
     pub const fn from_str(s: &str) -> Self {
-        let buf = crate::bytes::clone::<N>(s.as_bytes());
+        let buf = crate::bytes::clone::<N>(s.as_bytes(), 0);
         unsafe { Self::new_unchecked(buf) }
     }
 }

--- a/const-str/src/__ctfe/to_byte_array.rs
+++ b/const-str/src/__ctfe/to_byte_array.rs
@@ -37,8 +37,8 @@ macro_rules! to_byte_array {
 /// ```
 /// const S: &str = "hello";
 /// const B: &[u8; 6] = b"hello\0";
-/// assert_eq!(const_str::to_byte_array!(S), [b'h', b'e', b'l', b'l', b'o']);
-/// assert_eq!(const_str::to_byte_array!(B), [b'h', b'e', b'l', b'l', b'o', b'\0']);
+/// assert_eq!(const_str::to_byte_array_with_len!(S, 7, 0), [b'h', b'e', b'l', b'l', b'o', 0, 0]);
+/// assert_eq!(const_str::to_byte_array_with_len!(B, 7, 0), [b'h', b'e', b'l', b'l', b'o', b'\0', 0]);
 /// ```
 ///
 #[macro_export]

--- a/const-str/src/__ctfe/to_byte_array.rs
+++ b/const-str/src/__ctfe/to_byte_array.rs
@@ -1,14 +1,14 @@
 pub struct ToByteArray<T>(pub T);
 
 impl ToByteArray<&str> {
-    pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(self.0.as_bytes())
+    pub const fn const_eval<const N: usize>(&self, init_val: u8) -> [u8; N] {
+        crate::bytes::clone(self.0.as_bytes(), init_val)
     }
 }
 
 impl<const L: usize> ToByteArray<&[u8; L]> {
-    pub const fn const_eval<const N: usize>(&self) -> [u8; N] {
-        crate::bytes::clone(self.0)
+    pub const fn const_eval<const N: usize>(&self, init_val: u8) -> [u8; N] {
+        crate::bytes::clone(self.0, init_val)
     }
 }
 
@@ -26,6 +26,24 @@ impl<const L: usize> ToByteArray<&[u8; L]> {
 macro_rules! to_byte_array {
     ($s: expr) => {{
         const OUTPUT_LEN: usize = $s.len();
-        $crate::__ctfe::ToByteArray($s).const_eval::<OUTPUT_LEN>()
+        $crate::__ctfe::ToByteArray($s).const_eval::<OUTPUT_LEN>(0)
+    }};
+}
+
+/// Converts a string slice or a byte string to a byte array,
+/// provide a length of the array you'd create and fill with the initial value you expect.
+///
+/// # Examples
+/// ```
+/// const S: &str = "hello";
+/// const B: &[u8; 6] = b"hello\0";
+/// assert_eq!(const_str::to_byte_array!(S), [b'h', b'e', b'l', b'l', b'o']);
+/// assert_eq!(const_str::to_byte_array!(B), [b'h', b'e', b'l', b'l', b'o', b'\0']);
+/// ```
+///
+#[macro_export]
+macro_rules! to_byte_array_with_len {
+    ($s: expr, $len: expr, $init: expr) => {{
+        $crate::__ctfe::ToByteArray($s).const_eval::<$len>($init)
     }};
 }

--- a/const-str/src/__ctfe/to_char_array.rs
+++ b/const-str/src/__ctfe/to_char_array.rs
@@ -5,8 +5,8 @@ impl ToCharArray<&str> {
         crate::utf8::str_count_chars(self.0)
     }
 
-    pub const fn const_eval<const N: usize>(&self) -> [char; N] {
-        crate::utf8::str_chars(self.0)
+    pub const fn const_eval<const N: usize>(&self, fill: char) -> [char; N] {
+        crate::utf8::str_chars(self.0, fill)
     }
 }
 
@@ -23,7 +23,25 @@ macro_rules! to_char_array {
     ($s: expr) => {{
         const OUTPUT_LEN: usize = $crate::__ctfe::ToCharArray($s).output_len();
         const OUTPUT_BUF: [char; OUTPUT_LEN] =
-            $crate::__ctfe::ToCharArray($s).const_eval::<OUTPUT_LEN>();
+            $crate::__ctfe::ToCharArray($s).const_eval::<OUTPUT_LEN>('\0');
+        OUTPUT_BUF
+    }};
+}
+
+/// Converts a string slice into an array of its characters, 
+/// provide a length of the array you'd create and fill with the initial value you expect.
+///
+/// # Examples
+/// ```
+/// const CHARS: [char; 7] = const_str::to_char_array_with_len!("Hello", 7, '\0');
+/// assert_eq!(CHARS, ['H', 'e', 'l', 'l', 'o', '\0', '\0']);
+/// ```
+///
+#[macro_export]
+macro_rules! to_char_array_with_len {
+    ($s: expr, $len: expr, $fill: expr) => {{
+        const OUTPUT_BUF: [char; $len] =
+            $crate::__ctfe::ToCharArray($s).const_eval::<$len>($fill);
         OUTPUT_BUF
     }};
 }

--- a/const-str/src/bytes.rs
+++ b/const-str/src/bytes.rs
@@ -3,7 +3,7 @@ use crate::slice::subslice;
 use core::cmp::Ordering;
 
 pub const fn clone<const N: usize>(bytes: &[u8], init_val: u8) -> [u8; N] {
-    assert!(bytes.len() == N);
+    assert!(bytes.len() <= N);
     let mut buf = [init_val; N];
     let mut i = 0;
     while i < bytes.len() {

--- a/const-str/src/bytes.rs
+++ b/const-str/src/bytes.rs
@@ -2,9 +2,9 @@ use crate::slice::subslice;
 
 use core::cmp::Ordering;
 
-pub const fn clone<const N: usize>(bytes: &[u8]) -> [u8; N] {
+pub const fn clone<const N: usize>(bytes: &[u8], init_val: u8) -> [u8; N] {
     assert!(bytes.len() == N);
-    let mut buf = [0; N];
+    let mut buf = [init_val; N];
     let mut i = 0;
     while i < bytes.len() {
         buf[i] = bytes[i];

--- a/const-str/src/utf8.rs
+++ b/const-str/src/utf8.rs
@@ -263,7 +263,7 @@ pub const fn str_chars<const N: usize>(s: &str, init_val: char) -> [char; N] {
         buf[pos] = ch;
         pos += 1;
     }
-    assert!(pos == N);
+    assert!(pos <= N);
     buf
 }
 

--- a/const-str/src/utf8.rs
+++ b/const-str/src/utf8.rs
@@ -254,9 +254,9 @@ pub const fn str_count_chars(s: &str) -> usize {
     ans
 }
 
-pub const fn str_chars<const N: usize>(s: &str) -> [char; N] {
+pub const fn str_chars<const N: usize>(s: &str, init_val: char) -> [char; N] {
     let mut s = s.as_bytes();
-    let mut buf: [char; N] = ['\0'; N];
+    let mut buf: [char; N] = [init_val; N];
     let mut pos = 0;
     while let Some((ch, count)) = next_char(s) {
         s = advance(s, count);
@@ -327,7 +327,7 @@ mod tests {
     fn test_str_chars() {
         const X: &str = "唐可可";
         const OUTPUT_LEN: usize = str_count_chars(X);
-        const OUTPUT_BUF: [char; OUTPUT_LEN] = str_chars::<OUTPUT_LEN>(X);
+        const OUTPUT_BUF: [char; OUTPUT_LEN] = str_chars::<OUTPUT_LEN>(X, '\0');
         let ans = X.chars().collect::<Vec<_>>();
         assert_eq!(OUTPUT_BUF, ans.as_slice());
     }


### PR DESCRIPTION
您好 @Nugine 

我这边目前有个嵌入式Rust项目需要把一个compile-time constant的str转成`[u8; 32]`，然后我发现您这个库可以干类似的事情，但会报这种错误：

<img width="966" alt="image" src="https://github.com/Nugine/const-str/assets/4463497/2ec1e83c-3e10-451f-81eb-31a313592d35">

其中的`test_name`的类型即为`[u8; 32]`。

因此我这边简单写了个Pull request满足似乎可以我上述的需求，同时也可以指定初始值填充进这个数组里面。麻烦您先看下，如有纰漏烦请指出。

Jackson Hu
