### PR TITLE
feat: make net macros usable without std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: 
-          - 1.65.0 # MSRV
+          - 1.77.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 |               Toolchain               | Version |
 | :-----------------------------------: | :-----: |
-|      [Rust](https://rustup.rs/)       | ^1.65.0 |
+|      [Rust](https://rustup.rs/)       | ^1.77.0 |
 | [just](https://github.com/casey/just) | ^1.36.0 |
 
 ## Workflow

--- a/const-str/Cargo.toml
+++ b/const-str/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Nugine/const-str"
 keywords = ["string", "const", "proc-macro"]
 categories = ["text-processing", "no-std"]
 readme = "../README.md"
-rust-version = "1.65.0"
+rust-version = "1.77.0"
 
 [features]
 default = []

--- a/const-str/src/__ctfe/net.rs
+++ b/const-str/src/__ctfe/net.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 struct Parser<'a> {
     s: &'a [u8],
@@ -293,7 +293,7 @@ pub const fn expect_ip(s: &str) -> IpAddr {
 ///
 /// # Examples
 /// ```
-/// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+/// use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// use const_str::ip_addr;
 ///
 /// const LOCALHOST_V4: Ipv4Addr = ip_addr!(v4, "127.0.0.1");
@@ -301,7 +301,6 @@ pub const fn expect_ip(s: &str) -> IpAddr {
 ///
 /// const LOCALHOSTS: [IpAddr;2] = [ip_addr!("127.0.0.1"), ip_addr!("::1")];
 /// ```
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
 macro_rules! ip_addr {
     (v4, $s:expr) => {

--- a/const-str/src/lib.rs
+++ b/const-str/src/lib.rs
@@ -1,6 +1,6 @@
 //! Compile-time string operations
 //!
-//! MSRV: Rust 1.65.0
+//! MSRV: Rust 1.77.0
 //!
 #![deny(unsafe_code, missing_docs, clippy::all, clippy::cargo)]
 #![allow(

--- a/const-str/src/lib.rs
+++ b/const-str/src/lib.rs
@@ -80,11 +80,8 @@ pub mod __ctfe {
     mod hex;
     pub use self::hex::*;
 
-    #[cfg(feature = "std")]
-    item_group! {
-        mod net;
-        pub use self::net::*;
-    }
+    mod net;
+    pub use self::net::*;
 
     mod parse;
     pub use self::parse::*;


### PR DESCRIPTION
<!-- 
Thanks for your contributions! 

Here are the steps:
1. Write a comment explaining your changes
2. (Optional) Refer to related issues
3. (Optional) Request a new release if you wish
-->

Thanks for your work on this crate!

This PR makes the [`ip_addr!`](https://docs.rs/const-str/latest/const_str/macro.ip_addr.html) macro usable without std, as the reason why it wasn't yet available was that the IP address types were not in `core` yet.
I believe this would bump the MSRV of this crate from 1.65 (as documented in the [development guide](https://github.com/Nugine/const-str/blob/main/CONTRIBUTING.md)) to 1.77 (when the [`net` module has been introduced in `core`](https://doc.rust-lang.org/stable/core/net/index.html)).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
