### PR TITLE
Added support for `Train-Case` conversion

### DIFF
--- a/const-str-proc-macro/src/case.rs
+++ b/const-str-proc-macro/src/case.rs
@@ -13,6 +13,8 @@ enum Case {
     #[cfg(feature = "heck")]
     Title,
     #[cfg(feature = "heck")]
+    Train,
+    #[cfg(feature = "heck")]
     Snake,
     #[cfg(feature = "heck")]
     Kebab,
@@ -32,6 +34,7 @@ impl Case {
             ToShoutySnakeCase, //
             ToSnakeCase,       //
             ToTitleCase,       //
+            ToTrainCase,       //
             ToUpperCamelCase,  //
         };
         match self {
@@ -43,6 +46,8 @@ impl Case {
             Case::UpperCamel => s.to_upper_camel_case(),
             #[cfg(feature = "heck")]
             Case::Title => s.to_title_case(),
+            #[cfg(feature = "heck")]
+            Case::Train => s.to_train_case(),
             #[cfg(feature = "heck")]
             Case::Snake => s.to_snake_case(),
             #[cfg(feature = "heck")]
@@ -73,6 +78,8 @@ impl Parse for ConvertCase {
             "upper_camel" => Case::UpperCamel,
             #[cfg(feature = "heck")]
             "title" => Case::Title,
+            #[cfg(feature = "heck")]
+            "train" => Case::Train,
             #[cfg(feature = "heck")]
             "snake" => Case::Snake,
             #[cfg(feature = "heck")]

--- a/const-str-proc-macro/src/case.rs
+++ b/const-str-proc-macro/src/case.rs
@@ -11,6 +11,8 @@ enum Case {
     #[cfg(feature = "heck")]
     UpperCamel,
     #[cfg(feature = "heck")]
+    Title,
+    #[cfg(feature = "heck")]
     Snake,
     #[cfg(feature = "heck")]
     Kebab,
@@ -29,6 +31,7 @@ impl Case {
             ToShoutyKebabCase, //
             ToShoutySnakeCase, //
             ToSnakeCase,       //
+            ToTitleCase,       //
             ToUpperCamelCase,  //
         };
         match self {
@@ -38,6 +41,8 @@ impl Case {
             Case::LowerCamel => s.to_lower_camel_case(),
             #[cfg(feature = "heck")]
             Case::UpperCamel => s.to_upper_camel_case(),
+            #[cfg(feature = "heck")]
+            Case::Title => s.to_title_case(),
             #[cfg(feature = "heck")]
             Case::Snake => s.to_snake_case(),
             #[cfg(feature = "heck")]
@@ -66,6 +71,8 @@ impl Parse for ConvertCase {
             "lower_camel" => Case::LowerCamel,
             #[cfg(feature = "heck")]
             "upper_camel" => Case::UpperCamel,
+            #[cfg(feature = "heck")]
+            "title" => Case::Title,
             #[cfg(feature = "heck")]
             "snake" => Case::Snake,
             #[cfg(feature = "heck")]

--- a/const-str/src/__ctfe/ascii_case.rs
+++ b/const-str/src/__ctfe/ascii_case.rs
@@ -128,6 +128,7 @@ pub enum AsciiCase {
     LowerCamel,
     UpperCamel,
     Title,
+    Train,
     Snake,
     Kebab,
     ShoutySnake,
@@ -139,7 +140,7 @@ impl AsciiCase {
         match self {
             Self::Title => Some(b' '),
             Self::Snake | Self::ShoutySnake => Some(b'_'),
-            Self::Kebab | Self::ShoutyKebab => Some(b'-'),
+            Self::Train | Self::Kebab | Self::ShoutyKebab => Some(b'-'),
             _ => None,
         }
     }
@@ -154,7 +155,7 @@ impl ConvAsciiCase<&str> {
         use AsciiCase::*;
         match self.1 {
             Lower | Upper => self.0.len(),
-            LowerCamel | UpperCamel | Title | Snake | Kebab | ShoutySnake | ShoutyKebab => {
+            LowerCamel | UpperCamel | Title | Train | Snake | Kebab | ShoutySnake | ShoutyKebab => {
                 let mut ans = 0;
 
                 let has_sep = self.1.get_seperator().is_some();
@@ -210,7 +211,7 @@ impl ConvAsciiCase<&str> {
                     push!(s[pos].to_ascii_uppercase());
                 }
             }
-            LowerCamel | UpperCamel | Title | Snake | Kebab | ShoutySnake | ShoutyKebab => {
+            LowerCamel | UpperCamel | Title | Train | Snake | Kebab | ShoutySnake | ShoutyKebab => {
                 let sep = self.1.get_seperator();
 
                 let boundaries = Boundaries::<M>::new(self.0);
@@ -232,10 +233,10 @@ impl ConvAsciiCase<&str> {
                             let b = match self.1 {
                                 Snake | Kebab => word[j].to_ascii_lowercase(),
                                 ShoutySnake | ShoutyKebab => word[j].to_ascii_uppercase(),
-                                LowerCamel | UpperCamel | Title => {
+                                LowerCamel | UpperCamel | Title | Train => {
                                     let is_upper = match self.1 {
                                         LowerCamel => !is_starting_boundary && j == 0,
-                                        UpperCamel | Title => j == 0,
+                                        UpperCamel | Title | Train => j == 0,
                                         _ => unreachable!(),
                                     };
                                     if is_upper {
@@ -290,20 +291,22 @@ macro_rules! __conv_ascii_case {
 /// const S3: &str = convert_ascii_case!(lower_camel, "lower camel case");
 /// const S4: &str = convert_ascii_case!(upper_camel, "upper camel case");
 /// const S5: &str = convert_ascii_case!(title, "title case");
-/// const S6: &str = convert_ascii_case!(snake, "snake case");
-/// const S7: &str = convert_ascii_case!(kebab, "kebab case");
-/// const S8: &str = convert_ascii_case!(shouty_snake, "shouty snake case");
-/// const S9: &str = convert_ascii_case!(shouty_kebab, "shouty kebab case");
+/// const S6: &str = convert_ascii_case!(train, "train case");
+/// const S7: &str = convert_ascii_case!(snake, "snake case");
+/// const S8: &str = convert_ascii_case!(kebab, "kebab case");
+/// const S9: &str = convert_ascii_case!(shouty_snake, "shouty snake case");
+/// const S10: &str = convert_ascii_case!(shouty_kebab, "shouty kebab case");
 ///
 /// assert_eq!(S1, "lower case");
 /// assert_eq!(S2, "UPPER CASE");
 /// assert_eq!(S3, "lowerCamelCase");
 /// assert_eq!(S4, "UpperCamelCase");
 /// assert_eq!(S5, "Title Case");
-/// assert_eq!(S6, "snake_case");
-/// assert_eq!(S7, "kebab-case");
-/// assert_eq!(S8, "SHOUTY_SNAKE_CASE");
-/// assert_eq!(S9, "SHOUTY-KEBAB-CASE");
+/// assert_eq!(S6, "Train-Case");
+/// assert_eq!(S7, "snake_case");
+/// assert_eq!(S8, "kebab-case");
+/// assert_eq!(S9, "SHOUTY_SNAKE_CASE");
+/// assert_eq!(S10, "SHOUTY-KEBAB-CASE");
 /// ```
 #[macro_export]
 macro_rules! convert_ascii_case {
@@ -321,6 +324,9 @@ macro_rules! convert_ascii_case {
     };
     (title, $s: expr) => {
         $crate::__conv_ascii_case!($s, $crate::__ctfe::AsciiCase::Title)
+    };
+    (train, $s: expr) => {
+        $crate::__conv_ascii_case!($s, $crate::__ctfe::AsciiCase::Train)
     };
     (snake, $s: expr) => {
         $crate::__conv_ascii_case!($s, $crate::__ctfe::AsciiCase::Snake)
@@ -367,6 +373,11 @@ mod tests {
                 let c: String = $a.to_title_case();
                 test_conv_ascii_case!(heck, assert_eq, c.as_str(), $b);
             }};
+            (heck, train, $a: expr, $b: expr) => {{
+                use heck::ToTrainCase;
+                let c: String = $a.to_train_case();
+                test_conv_ascii_case!(heck, assert_eq, c.as_str(), $b);
+            }};
             (heck, snake, $a: expr, $b: expr) => {{
                 use heck::ToSnakeCase;
                 let c: String = $a.to_snake_case();
@@ -394,6 +405,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "b8");
             test_conv_ascii_case!(upper_camel, S, "B8");
             test_conv_ascii_case!(title, S, "B 8");
+            test_conv_ascii_case!(train, S, "B-8");
             test_conv_ascii_case!(snake, S, "b_8");
             test_conv_ascii_case!(kebab, S, "b-8");
             test_conv_ascii_case!(shouty_snake, S, "B_8");
@@ -405,6 +417,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "helloWorld123XmlHttp我4t5C67b8");
             test_conv_ascii_case!(upper_camel, S, "HelloWorld123XmlHttp我4t5C67b8");
             test_conv_ascii_case!(title, S, "Hello World123 Xml Http 我 4t5 C6 7b 8");
+            test_conv_ascii_case!(train, S, "Hello-World123-Xml-Http-我-4t5-C6-7b-8");
             test_conv_ascii_case!(snake, S, "hello_world123_xml_http_我_4t5_c6_7b_8");
             test_conv_ascii_case!(kebab, S, "hello-world123-xml-http-我-4t5-c6-7b-8");
             test_conv_ascii_case!(shouty_snake, S, "HELLO_WORLD123_XML_HTTP_我_4T5_C6_7B_8");
@@ -415,6 +428,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "xmlHttpRequest");
             test_conv_ascii_case!(upper_camel, S, "XmlHttpRequest");
             test_conv_ascii_case!(title, S, "Xml Http Request");
+            test_conv_ascii_case!(train, S, "Xml-Http-Request");
             test_conv_ascii_case!(snake, S, "xml_http_request");
             test_conv_ascii_case!(kebab, S, "xml-http-request");
             test_conv_ascii_case!(shouty_snake, S, "XML_HTTP_REQUEST");
@@ -425,6 +439,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "helloWorld");
             test_conv_ascii_case!(upper_camel, S, "HelloWorld");
             test_conv_ascii_case!(title, S, "Hello World");
+            test_conv_ascii_case!(train, S, "Hello-World");
             test_conv_ascii_case!(snake, S, "hello_world");
             test_conv_ascii_case!(kebab, S, "hello-world");
             test_conv_ascii_case!(shouty_snake, S, "HELLO_WORLD");
@@ -435,6 +450,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "");
             test_conv_ascii_case!(upper_camel, S, "");
             test_conv_ascii_case!(title, S, "");
+            test_conv_ascii_case!(train, S, "");
             test_conv_ascii_case!(snake, S, "");
             test_conv_ascii_case!(kebab, S, "");
             test_conv_ascii_case!(shouty_snake, S, "");
@@ -445,6 +461,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "");
             test_conv_ascii_case!(upper_camel, S, "");
             test_conv_ascii_case!(title, S, "");
+            test_conv_ascii_case!(train, S, "");
             test_conv_ascii_case!(snake, S, "");
             test_conv_ascii_case!(kebab, S, "");
             test_conv_ascii_case!(shouty_snake, S, "");
@@ -455,6 +472,7 @@ mod tests {
             test_conv_ascii_case!(lower_camel, S, "12e3");
             test_conv_ascii_case!(upper_camel, S, "12e3");
             test_conv_ascii_case!(title, S, "1 2e3");
+            test_conv_ascii_case!(train, S, "1-2e3");
             test_conv_ascii_case!(snake, S, "1_2e3");
             test_conv_ascii_case!(kebab, S, "1-2e3");
             test_conv_ascii_case!(shouty_snake, S, "1_2E3");
@@ -464,6 +482,8 @@ mod tests {
             const S: &str = "__a__b-c__d__";
             test_conv_ascii_case!(lower_camel, S, "aBCD");
             test_conv_ascii_case!(upper_camel, S, "ABCD");
+            test_conv_ascii_case!(title, S, "A B C D");
+            test_conv_ascii_case!(train, S, "A-B-C-D");
             test_conv_ascii_case!(snake, S, "a_b_c_d");
             test_conv_ascii_case!(kebab, S, "a-b-c-d");
             test_conv_ascii_case!(shouty_snake, S, "A_B_C_D");
@@ -473,6 +493,8 @@ mod tests {
             const S: &str = "futures-core123";
             test_conv_ascii_case!(lower_camel, S, "futuresCore123");
             test_conv_ascii_case!(upper_camel, S, "FuturesCore123");
+            test_conv_ascii_case!(title, S, "Futures Core123");
+            test_conv_ascii_case!(train, S, "Futures-Core123");
             test_conv_ascii_case!(snake, S, "futures_core123");
             test_conv_ascii_case!(kebab, S, "futures-core123");
             test_conv_ascii_case!(shouty_snake, S, "FUTURES_CORE123");

--- a/const-str/src/__proc/case.rs
+++ b/const-str/src/__proc/case.rs
@@ -10,6 +10,7 @@ These variants require the feature `case`.
 + lower_camel
 + upper_camel
 + title
++ train
 + kebab
 + snake
 + shouty_snake
@@ -28,13 +29,15 @@ const S4: &str = convert_case!(upper_camel, "upper camel case");
 # #[cfg(feature = "case")]
 const S5: &str = convert_case!(title, "title case");
 # #[cfg(feature = "case")]
-const S6: &str = convert_case!(snake, "snake case");
+const S6: &str = convert_case!(train, "train case");
 # #[cfg(feature = "case")]
-const S7: &str = convert_case!(kebab, "kebab case");
+const S7: &str = convert_case!(snake, "snake case");
 # #[cfg(feature = "case")]
-const S8: &str = convert_case!(shouty_snake, "shouty snake case");
+const S8: &str = convert_case!(kebab, "kebab case");
 # #[cfg(feature = "case")]
-const S9: &str = convert_case!(shouty_kebab, "shouty kebab case");
+const S9: &str = convert_case!(shouty_snake, "shouty snake case");
+# #[cfg(feature = "case")]
+const S10: &str = convert_case!(shouty_kebab, "shouty kebab case");
 
 assert_eq!(S1, "lower case");
 assert_eq!(S2, "UPPER CASE");
@@ -45,13 +48,15 @@ assert_eq!(S4, "UpperCamelCase");
 # #[cfg(feature = "case")]
 assert_eq!(S5, "Title Case");
 # #[cfg(feature = "case")]
-assert_eq!(S6, "snake_case");
+assert_eq!(S6, "Train-Case");
 # #[cfg(feature = "case")]
-assert_eq!(S7, "kebab-case");
+assert_eq!(S7, "snake_case");
 # #[cfg(feature = "case")]
-assert_eq!(S8, "SHOUTY_SNAKE_CASE");
+assert_eq!(S8, "kebab-case");
 # #[cfg(feature = "case")]
-assert_eq!(S9, "SHOUTY-KEBAB-CASE");
+assert_eq!(S9, "SHOUTY_SNAKE_CASE");
+# #[cfg(feature = "case")]
+assert_eq!(S10, "SHOUTY-KEBAB-CASE");
 ```
 "#
     };
@@ -88,6 +93,9 @@ macro_rules! convert_case {
     };
     (title, $s: literal) => {
         $crate::__proc::convert_case!(title, $s)
+    };
+    (train, $s: literal) => {
+        $crate::__proc::convert_case!(train, $s)
     };
     (snake, $s: literal) => {
         $crate::__proc::convert_case!(snake, $s)

--- a/const-str/src/__proc/case.rs
+++ b/const-str/src/__proc/case.rs
@@ -9,6 +9,7 @@ These variants require the feature `case`.
 
 + lower_camel
 + upper_camel
++ title
 + kebab
 + snake
 + shouty_snake
@@ -25,13 +26,15 @@ const S3: &str = convert_case!(lower_camel, "lower camel case");
 # #[cfg(feature = "case")]
 const S4: &str = convert_case!(upper_camel, "upper camel case");
 # #[cfg(feature = "case")]
-const S5: &str = convert_case!(snake, "snake case");
+const S5: &str = convert_case!(title, "title case");
 # #[cfg(feature = "case")]
-const S6: &str = convert_case!(kebab, "kebab case");
+const S6: &str = convert_case!(snake, "snake case");
 # #[cfg(feature = "case")]
-const S7: &str = convert_case!(shouty_snake, "shouty snake case");
+const S7: &str = convert_case!(kebab, "kebab case");
 # #[cfg(feature = "case")]
-const S8: &str = convert_case!(shouty_kebab, "shouty kebab case");
+const S8: &str = convert_case!(shouty_snake, "shouty snake case");
+# #[cfg(feature = "case")]
+const S9: &str = convert_case!(shouty_kebab, "shouty kebab case");
 
 assert_eq!(S1, "lower case");
 assert_eq!(S2, "UPPER CASE");
@@ -40,13 +43,15 @@ assert_eq!(S3, "lowerCamelCase");
 # #[cfg(feature = "case")]
 assert_eq!(S4, "UpperCamelCase");
 # #[cfg(feature = "case")]
-assert_eq!(S5, "snake_case");
+assert_eq!(S5, "Title Case");
 # #[cfg(feature = "case")]
-assert_eq!(S6, "kebab-case");
+assert_eq!(S6, "snake_case");
 # #[cfg(feature = "case")]
-assert_eq!(S7, "SHOUTY_SNAKE_CASE");
+assert_eq!(S7, "kebab-case");
 # #[cfg(feature = "case")]
-assert_eq!(S8, "SHOUTY-KEBAB-CASE");
+assert_eq!(S8, "SHOUTY_SNAKE_CASE");
+# #[cfg(feature = "case")]
+assert_eq!(S9, "SHOUTY-KEBAB-CASE");
 ```
 "#
     };
@@ -80,6 +85,9 @@ macro_rules! convert_case {
     };
     (upper_camel, $s: literal) => {
         $crate::__proc::convert_case!(upper_camel, $s)
+    };
+    (title, $s: literal) => {
+        $crate::__proc::convert_case!(title, $s)
     };
     (snake, $s: literal) => {
         $crate::__proc::convert_case!(snake, $s)


### PR DESCRIPTION
Similar to yesterday's `Title Case` conversion, but with `-` as a separator (`Train-Case`).